### PR TITLE
Fix CircleCI example

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -131,7 +131,7 @@ workflows:
   lint:
     jobs:
       - docker/hadolint:
-          dockerfile: path/to/Dockerfile
+          dockerfiles: 'path/to/Dockerfile,path/to/another/Dockerfile'
           ignore-rules: 'DL4005,DL3008'
           trusted-registries: 'docker.io,my-company.com:5000'
 ```


### PR DESCRIPTION
### What I did
Fixed the INTEGRATION docs for CircleCI. The `dockerfile:` key was renamed to `dockerfiles:` and the example made to illustrate it supports a comma-separated list.

### How I did it
Edited markdown file.

### How to verify it
I discovered this by following the docs and getting an error that the `dockerfile` param was not supported. Through trial and error I discovered that pluralizing made it work. To test, push a repo through CircleCI with this example config, and configure it with two different Dockerfiles you'd like to run through hadolint.